### PR TITLE
Enhancement of vis_artifacts

### DIFF
--- a/vis_artifacts.m
+++ b/vis_artifacts.m
@@ -26,7 +26,7 @@ function [h_old,h_new] = vis_artifacts(new,old,varargin)
 %                'OldColor' : color of the old (i.e., uncleaned) data
 %                'HighpassOldData' : whether to high-pass the old data if not already done
 %                'ScaleBy' : the data set according to which the display should be scaled, can be
-%                            'old' or 'new' (default: 'new')
+%                            'old', 'new' or 'noscale' (default: 'new')
 %                'ChannelSubset' : optionally a channel subset to display
 %                'TimeSubet' : optionally a time subrange to display
 %                'DisplayMode' : what should be displayed: 'both', 'new', 'old', 'diff'
@@ -88,7 +88,7 @@ opts = hlp_varargin2struct(varargin, ...
     {'show_removed_portions','ShowRemovedPortions'},true, ...% whether to show removed data portions (if only one set is passed in)
     {'show_events','ShowEvents'},true, ...      % whether to show events
     {'show_eventlegend','ShowEventLegend'},false, ...  % whether to show a legend for the currently visible events
-    {'scale_by','ScaleBy'},'allnew',...         % the data set according to which the display should be scaled (can be allold, allnew, wndold, or wndnew)
+    {'scale_by','ScaleBy'},'allnew',...         % the data set according to which the display should be scaled (can be allold, allnew, wndold, wndnew or noscale)
     {'channel_subset','ChannelSubset'},[], ...  % optionally a channel subset to display
     {'time_subset','TimeSubset'},[],...         % optionally a time subrange to display
     {'display_mode','DisplayMode'},'both',...   % what should be displayed: 'both', 'new', 'old', 'diff'
@@ -214,6 +214,8 @@ set(hFig, 'ResizeFcn', @on_window_resized);
                 iqrange(isnan(iqrange)) = mad(oldwnd(isnan(iqrange),:)',1)';
             case {'wndold','old'}
                 iqrange = mad(oldwnd',1)';
+            case 'noscale'
+                iqrange = ones(size(new.data,1),1);
             otherwise
                 error('Unsupported scale_by option.');
         end

--- a/vis_artifacts.m
+++ b/vis_artifacts.m
@@ -196,6 +196,12 @@ set(hFig, 'ResizeFcn', @on_window_resized);
         ylr = yl(1) + opts.yrange*(yl(2)-yl(1));
         channel_y = (ylr(2):(ylr(1)-ylr(2))/(size(new.data,1)-1):ylr(1))';
         
+        % Add channel labels to y axis
+        if isfield(old.chanlocs,'labels')
+            set(hAxis,'ytick',flipud(channel_y));
+            set(hAxis,'yticklabel',fliplr({old.chanlocs.labels}));
+        end
+        
         % compute sample range
         wndsamples = opts.wndlen * new.srate;
         pos = floor((size(new.data,2)-wndsamples)*relPos);


### PR DESCRIPTION
Dear Christian Kothe,

I would like to suggest adding an option of no scaling the channel data with respect to the old or new standard deviation of the channels. The rationale can be gather from the following personal example. After cleaning the line noise and performing ICA on my data I wanted to check the difference between the raw and the preprocessed data. Therefore I run something like `vis_artifacts(EEGClean,EEGraw);` and obtained this image:
![Scroll_after_ICA_crd_default_sub-01_allnew](https://user-images.githubusercontent.com/18517243/145011490-7c4910fd-f06a-45f7-908f-33559085747f.png)
To my surprise C4 didn't look bad at all, when I knew beforehand that it had a high standard deviation in amplitude (I plotted it with pop_eegplot). That was due to the scaling of C4 was the same in the clean and raw data. Therefore I just introduced an option to 'ScaleBy' where no scaling was applied (see code). After running
`opts.ScaleBy = 'noscale'; opts.yscaling = 50;
vis_artifacts(EEGClean,EEGraw,opts);`
I get an image like this one
![Scroll_after_ICA_nobadchans_sub-01](https://user-images.githubusercontent.com/18517243/145012553-50703d26-6742-4f9a-8a27-5c6126e577f0.png)

I believe this option would be useful to explore your data cleaning when some obviously bad channels have not been eliminated. I therefore hope you consider this PR. I look forward to your feedback!

PS: I have also included the suggestion by Arno Delorme in issue #2 to include the channel labels, which I also found very useful.